### PR TITLE
Adding docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ Spring Boot is a widely used Java framework that simplifies the development of r
 
 ## Getting Started
 
-To run this project locally, follow these steps:
+### Requisites
+1. Java 17 or higher
+2. docker and docker-compose installed
+
+To run this project locally, you need to have follow the following:
+
 1. Clone the repository: `git clone https://github.com/BrunoAotoPelissari/spring-boot-studies`
 2. Navigate to the project directory: `cd spring-boot-studies`
-3. Build the project: `mvn clean install`
-4. Run the application: `java -jar target/spring-boot-studies.jar`
+3. run in your terminal `docker-compose up -d`
+4. run in your terminal `mvn spring-boot:run`
 
+To check if everything is running fine, you can access `localhost:8080/api/v1/student` and it should return a proper json response.
 
 ## Project Structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  postgres:
+    image: postgres:10.7
+    volumes:
+      - student_postgres/lib/postgresql/data
+    networks:
+      - lc_network
+    environment:
+      - "POSTGRES_DB=student"
+    ports:
+      - 5432:5432 
+
+networks:
+  lc_network:
+    driver: bridge
+volumes:
+  student_postgres:


### PR DESCRIPTION
This PR adds a `docker-compose.yml` file setting up a PostgreSQL database so we can run the project locally without the need to install PostgreSQL locally in our machine.

Also I add information in `README.md` file about how you can use `docker-compose` and `mvn spring boot` plugin to start the application without worry about jar application name + version.